### PR TITLE
Call issue.status instead of issue.issue_status, fix #9

### DIFF
--- a/lib/ekanban/issue_patch.rb
+++ b/lib/ekanban/issue_patch.rb
@@ -70,12 +70,12 @@ module EKanban
 
           state_id = IssueStatusKanbanState.state_id(issue.status_id, issue.tracker_id)
           if (state_id.nil?)
-            errors.add(:status_id, ":No kanban state associated with status '#{issue.issue_status.name}', contact redmine admin!")
+            errors.add(:status_id, ":No kanban state associated with status '#{issue.status.name}', contact redmine admin!")
             return false
           end
           pane = KanbanPane.pane_by(state_id, kanban)
           if pane.nil?
-            errors.add(:status_id, ":No kanban pane associated with status '#{issue.issue_status.name}', contact redmine admin!")
+            errors.add(:status_id, ":No kanban pane associated with status '#{issue.status.name}', contact redmine admin!")
             return false
           end
 


### PR DESCRIPTION
I'm still affected by bug #9:

```
NoMethodError (undefined method issue_status' for #<Issue:0x007ffc7bea5db0>): app/controllers/issues_controller.rb:137:increate'
```

This commit changes calls to Issue#issue_status to Issue#status. It works for me.
