### PR TITLE
Use url_for instead of composing it in order to get a relative URL

### DIFF
--- a/app/views/kanban_stages/index.html.haml
+++ b/app/views/kanban_stages/index.html.haml
@@ -1,2 +1,2 @@
 :javascript
-  window.location.href="/kanban_states/setup?tab=Stages"
+  window.location.href="#{url_for :controller => "kanban_states", :action => "setup", :tab => 'Stages'}"


### PR DESCRIPTION
I run Redmine from a relative root URL (/redmine). After creating a Kanban Stage I'm redirected to a unknown URL because it's composed by hand instead of using Rails methods. This patch fixes it.
