### PR TITLE
Hopefully fixes issue #29

### DIFF
--- a/app/controllers/issue_status_kanban_states_controller.rb
+++ b/app/controllers/issue_status_kanban_states_controller.rb
@@ -15,7 +15,7 @@ class IssueStatusKanbanStatesController < ApplicationController
 			puts addeds
 
 			removeds.each do |r|
-				rec = IssueStatusKanbanState.find_by_issue_status_id_and_kanban_state_id(v,k)
+				rec = IssueStatusKanbanState.find_by_issue_status_id_and_kanban_state_id(r,k)
 				rec.delete if rec
 			end
 


### PR DESCRIPTION
Updating the mapping between Issue Status and Kanban state was deleting
one of the mappings to keep rather than the mapping that was wanting to
be deleted.
