### PR TITLE
Update documentation to explicitly set Rail Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Add "gem 'haml'" to your #{RAILS_ROOT}/Gemfile
 In #{RAILS_ROOT} run the command
         
     bundle install
-    rake redmine:plugins:migrate
+    rake redmine:plugins:migrate RAILS_ENV=production
+
+(or change production to whatever Rails environment you are using).
+
   
 Restart Redmine
 


### PR DESCRIPTION
If you don't specify the Rails environment when running the plugin migration then it will use the default environment, which is often not the one users want to use. Have had a couple of issues raised ( #33 and #36 ) where people have found the migration failed because it was running the migration on the Development rather than the Production
Rails environment.

Updated the documentation to say that you should explicitly set the Rails Environment when running the plugin migration.
