### PR TITLE
Added gemfile for haml requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem "haml", "~> 4.0.5"
+


### PR DESCRIPTION
The gem are added when you do a bundle install at the root of your Redmine installation. There is no need to add it to the main Gemfile.
With that we can prevent having to modify the Redmine global Gemfile (which can change with update).
